### PR TITLE
gate/model: fix "clone" method for GNet

### DIFF
--- a/src/gate/model/gnet.cpp
+++ b/src/gate/model/gnet.cpp
@@ -664,28 +664,23 @@ GNet *GNet::clone() {
 
 GNet *GNet::clone(std::unordered_map<Gate::Id, Gate::Id> &oldToNewId) {
   GNet *resultNet = new GNet(_level);
-  if (oldToNewId.empty()) {
-    for (Gate *gate : _gates) {
-      SignalList newSignals;
-      Gate *newGate = new Gate(gate->func(), newSignals);
-      oldToNewId[gate->id()] = newGate->id();
-    }
-  
-    for (Gate *gate : _gates) {
-      SignalList newSignals;
-      newSignals.reserve(gate->_inputs.capacity());
-      for (Signal signal : gate->inputs()) {
-        newSignals.push_back(Signal(signal.event(), oldToNewId[signal.node()]));
-      }
-      Gate::Id newGateId = oldToNewId[gate->id()];
-      Gate::get(newGateId)->setInputs(newSignals);
-      resultNet->addGate(Gate::get(newGateId));
-    }
-  } else {
-    for (Gate *gate : _gates) {
-      resultNet->addGate(Gate::get(oldToNewId[gate->id()]));
-    }
+
+  assert(oldToNewId.empty());
+
+  for (Gate *gate : _gates) {
+    oldToNewId[gate->id()] = resultNet->newGate();
   }
+  
+  for (Gate *gate : _gates) {
+    SignalList newSignals;
+    newSignals.reserve(gate->_inputs.capacity());
+    for (Signal signal : gate->inputs()) {
+      newSignals.push_back(Signal(signal.event(), oldToNewId[signal.node()]));
+    }
+    Gate::Id newGateId = oldToNewId[gate->id()];
+    resultNet->setGate(newGateId, gate->func(), newSignals);
+  }
+
   if (!_subnets.empty()) {
     for (GNet *subnet : _subnets) {
       resultNet->addSubnet(subnet->clone(oldToNewId));


### PR DESCRIPTION
To avoid clang-tidy warnings some refactoring is made. Some convenience methods are used (newGate, setGate). Moreover, for parameterized "clone" method an assumption is made, that input map is empty upon method calling.